### PR TITLE
unset fast key-repeat

### DIFF
--- a/macos.sh
+++ b/macos.sh
@@ -64,8 +64,11 @@ defaults write NSGlobalDomain AppleKeyboardUIMode -int 3
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
 
 # Set a blazingly fast keyboard repeat rate
-defaults write NSGlobalDomain KeyRepeat -int 1
-defaults write NSGlobalDomain InitialKeyRepeat -int 10
+# defaults write NSGlobalDomain KeyRepeat -int 1
+# defaults write NSGlobalDomain InitialKeyRepeat -int 10
+# OR to undo the above and restore defaults
+# defaults write NSGlobalDomain KeyRepeat -int 6
+# defaults write NSGlobalDomain InitialKeyRepeat -int 25
 
 ###############################################################################
 # Energy saving                                                               #


### PR DESCRIPTION
I can't handle the blazingly fast key repeat. I think it's best for everyone if this is not set so fast.